### PR TITLE
Correct service->target

### DIFF
--- a/kekeo/modules/kerberos/kuhl_m_kerberos.c
+++ b/kekeo/modules/kerberos/kuhl_m_kerberos.c
@@ -289,7 +289,7 @@ NTSTATUS kuhl_m_kerberos_ask(int argc, wchar_t * argv[])
 	KRB_CRED *KrbCred = NULL;
 	EncKrbCredPart *encKrbCred = NULL;
 
-	if(kull_m_string_args_byName(argc, argv, L"service", &szTarget, NULL))
+	if(kull_m_string_args_byName(argc, argv, L"target", &szTarget, NULL))
 	{
 		dwTarget = (USHORT) ((wcslen(szTarget) + 1) * sizeof(wchar_t));
 


### PR DESCRIPTION
Mimi and Kekeo both ask for /target: for kerberos::ask but kekeo uses /service: