### PR TITLE
Allow usage of CNG, in addition to CryptoAPI, for CryptAcquireCertificatePrivateKey

### DIFF
--- a/modules/asn1/kull_m_kerberos_asn1_crypto.c
+++ b/modules/asn1/kull_m_kerberos_asn1_crypto.c
@@ -121,7 +121,7 @@ BOOL kull_m_kerberos_asn1_crypto_get_CertInfo(PCWSTR Subject, PKULL_M_CRYPTO_CER
 	RtlZeroMemory(certInfo, sizeof(KULL_M_CRYPTO_CERT_INFO));
 	if(certInfo->hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM, 0, (HCRYPTPROV_LEGACY) NULL, CERT_SYSTEM_STORE_CURRENT_USER | CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG, L"My"))
 		if(certInfo->pCertContext = CertFindCertificateInStore(certInfo->hCertStore, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0, CERT_FIND_SUBJECT_STR, Subject, NULL))
-			status = CryptAcquireCertificatePrivateKey(certInfo->pCertContext, CRYPT_ACQUIRE_CACHE_FLAG, NULL, &certInfo->provider.hProv, &certInfo->provider.dwKeySpec, &keyToFree);
+			status = CryptAcquireCertificatePrivateKey(certInfo->pCertContext, CRYPT_ACQUIRE_CACHE_FLAG | CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG, NULL, &certInfo->provider.hProv, &certInfo->provider.dwKeySpec, &keyToFree);
 	if(!status)
 		kull_m_kerberos_asn1_crypto_free_CertInfo(certInfo);
 	return status;


### PR DESCRIPTION
I did some tests where it did not find my certificate with the current Kekeo build (`CryptAcquireCertificatePrivateKey` returned FALSE).

After adding `CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG` it works :)
(FYI I did it with a before-call breakpoint in API Monitor on `CryptAcquireCertificatePrivateKey`, and by replacing the second parameter, "1", by "65537")

The code already uses this flag in another method:
https://github.com/gentilkiwi/kekeo/blob/8fba41185516113d3cc2b8ff78122b5579bb7632/modules/asn1/kull_m_kerberos_asn1_crypto.c#L515