### PR TITLE
tsssp: add policy registry key names

### DIFF
--- a/kekeo/modules/kuhl_m_tsssp.c
+++ b/kekeo/modules/kuhl_m_tsssp.c
@@ -173,7 +173,7 @@ NTSTATUS kuhl_m_tsssp_list(int argc, wchar_t * argv[])
 	return STATUS_SUCCESS;
 }
 
-LPCWCHAR AllowToCheckData[] = {L"AllowDefaultCredentials", L"AllowDefaultCredentialsDomain", L"AllowDefaultCredentialsWhenNTLMOnly", L"AllowDefaultCredentialsWhenNTLMOnlyDomain"};
+LPCWCHAR AllowToCheckData[] = {L"AllowDefaultCredentials", L"AllowDefaultCredentialsDomain", L"AllowDefaultCredentialsWhenNTLMOnly", L"AllowDefCredentialsWhenNTLMOnly", L"AllowDefaultCredentialsWhenNTLMOnlyDomain", L"AllowDefCredentialsWhenNTLMOnlyDomain"};
 void kuhl_m_tsssp_list_data(HKEY hPd)
 {
 	HKEY hData;


### PR DESCRIPTION
This PR comes from the following observation.

I enabled the "delegation for default credentials with NTLM-only servers" using the Group Policy Editor. I obtained this in registry:
![image](https://user-images.githubusercontent.com/550823/58371356-ee8e0580-7f10-11e9-93b9-1bcf058561ac.png)

The key name is thus `AllowDefCredentialsWhenNTLMOnly`, as confirmed by [the ADMX file](https://getadmx.com/?Category=Windows_10_2016&Policy=Microsoft.Policies.CredentialsSSP::AllowDefCredentialsWhenNTLMOnly).

Before the PR, kekeo fails to retrieve it due to using an incorrect name:
![image](https://user-images.githubusercontent.com/550823/58371388-2e54ed00-7f11-11e9-9f2a-5f5648511d85.png)

After the PR (actually I binary edited the executable):
![image](https://user-images.githubusercontent.com/550823/58371404-3b71dc00-7f11-11e9-8272-e7579b18c2de.png)

This is what I initially intended to suggest. However, it still seems that `AllowDefaultCredentialsWhenNTLMOnly` is a valid name.
According to a few Google searches:
- `AllowDefaultCredentialsWhenNTLMOnly` is used to the default CredSSP policy ([source](https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-group-policy-and-registry-settings))
- `AllowDefCredentialsWhenNTLMOnly` is used for the defined policy ([source](https://getadmx.com/?Category=Windows_10_2016&Policy=Microsoft.Policies.CredentialsSSP::AllowDefCredentialsWhenNTLMOnly))

Since the same `kuhl_m_tsssp_list_data` function is used for both, I finally suggest to include both spelling to ensure to collect everything...

I also suggest to apply the same logic to `AllowDefaultCredentialsWhenNTLMOnlyDomain`/`AllowDefCredentialsWhenNTLMOnlyDomain` even if I do not find any trace of the latter on Google.