### PR TITLE
kerberos::ask parameter is "/service" and not "/target"

### DIFF
--- a/kekeo/modules/kerberos/kuhl_m_kerberos.c
+++ b/kekeo/modules/kerberos/kuhl_m_kerberos.c
@@ -349,6 +349,6 @@ NTSTATUS kuhl_m_kerberos_ask(int argc, wchar_t * argv[])
 			LocalFree(pKerbRetrieveRequest);
 		}
 	}
-	else PRINT_ERROR(L"At least /target argument is required (eg: /target:cifs/server.lab.local)\n");
+	else PRINT_ERROR(L"At least /service argument is required (eg: /service:cifs/server.lab.local)\n");
 	return STATUS_SUCCESS;
 }


### PR DESCRIPTION
As we can see here:
https://github.com/gentilkiwi/kekeo/blob/8326af87720e6743cd978a5962da8b2b81fa284a/kekeo/modules/kerberos/kuhl_m_kerberos.c#L289