### PR TITLE
docs: fix simple typo, stucture -> structure

### DIFF
--- a/inc/Winldap.h
+++ b/inc/Winldap.h
@@ -658,7 +658,7 @@ WINLDAPAPI LDAP * LDAPAPI cldap_open( __in PCHAR HostName, ULONG PortNumber );
 //  ldap_bind on the connection.
 //
 //  multi-thread: ldap_unbind* calls are safe EXCEPT don't use the LDAP *
-//                stucture after it's been freed.
+//                structure after it's been freed.
 //
 
 WINLDAPAPI ULONG LDAPAPI ldap_unbind( LDAP *ld );


### PR DESCRIPTION
There is a small typo in inc/Winldap.h.

Should read `structure` rather than `stucture`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md